### PR TITLE
initial support for loading langs via config file

### DIFF
--- a/nvim/lua/config/langs.lua
+++ b/nvim/lua/config/langs.lua
@@ -1,0 +1,18 @@
+---@type NvimLanguageConfig
+local lang_config = {
+	enabled_langs = {
+		"lua",
+		"python",
+		"rust",
+		"markdown",
+		"svelte",
+		"html",
+		"typescript",
+		"bash",
+		"cpp",
+		"dockerfile",
+	},
+	custom_lang_defs = {},
+}
+
+return lang_config

--- a/nvim/lua/config/types.lua
+++ b/nvim/lua/config/types.lua
@@ -1,0 +1,15 @@
+---@alias BuiltinLangs
+---| "lua"
+---| "python"
+---| "rust"
+---| "markdown"
+---| "svelte"
+---| "html"
+---| "typescript"
+---| "bash"
+---| "cpp"
+---| "dockerfile"
+
+---@class NvimLanguageConfig
+---@field enabled_langs BuiltinLangs[] The list of enabled languages
+---@field custom_lang_defs LanguageDefinition[] A list of custom language definitions

--- a/nvim/lua/core/langs/cpp.lua
+++ b/nvim/lua/core/langs/cpp.lua
@@ -1,0 +1,19 @@
+---@type LanguageDefinition
+local M = {
+	lang_name = "cpp",
+
+	formatters = {
+		"clang-format",
+	},
+
+	linters = {},
+
+	lsp_servers = {
+		{
+			lsp_name = "clangd",
+			lsp_settings = {},
+		},
+	},
+}
+
+return M

--- a/nvim/lua/core/langs/docker.lua
+++ b/nvim/lua/core/langs/docker.lua
@@ -1,0 +1,17 @@
+---@type LanguageDefinition
+local M = {
+	lang_name = "dockerfile",
+
+	formatters = {},
+
+	linters = {},
+
+	lsp_servers = {
+		{
+			lsp_name = "dockerls",
+			lsp_settings = {},
+		},
+	},
+}
+
+return M

--- a/nvim/lua/core/langs/dockerfile.lua
+++ b/nvim/lua/core/langs/dockerfile.lua
@@ -1,0 +1,17 @@
+---@type LanguageDefinition
+local M = {
+	lang_name = "dockerfile",
+
+	formatters = {},
+
+	linters = {},
+
+	lsp_servers = {
+		{
+			lsp_name = "dockerls",
+			lsp_settings = {},
+		},
+	},
+}
+
+return M

--- a/nvim/lua/core/langs/init.lua
+++ b/nvim/lua/core/langs/init.lua
@@ -1,21 +1,18 @@
-local lua = require("core.langs.lua")
-local python = require("core.langs.python")
-local rust = require("core.langs.rust")
-local markdown = require("core.langs.markdown")
-local svelte = require("core.langs.svelte")
-local html = require("core.langs.html")
-local typescript = require("core.langs.typescript")
-local bash = require("core.langs.bash")
+local lang_config = require("config.langs")
 
-local M = {
-	[lua.lang_name] = lua,
-	[python.lang_name] = python,
-	[rust.lang_name] = rust,
-	[markdown.lang_name] = markdown,
-	[svelte.lang_name] = svelte,
-	[html.lang_name] = html,
-	[typescript.lang_name] = typescript,
-	[bash.lang_name] = bash,
-}
+local M = {}
+
+-- load the builtin langues that have been enabled
+for _, value in ipairs(lang_config.enabled_langs) do
+	local success, this_lang_config = pcall(require, "core.langs." .. value)
+	if success == true then
+		M[this_lang_config.lang_name] = this_lang_config
+	end
+end
+
+-- load any custom language definitions
+for _, value in ipairs(lang_config.custom_lang_defs) do
+	M[value.lang_name] = value
+end
 
 return M

--- a/nvim/lua/core/types.lua
+++ b/nvim/lua/core/types.lua
@@ -4,7 +4,7 @@
 
 ---@class LanguageDefinition
 ---@field lang_name string The name of this language, eg. "lua"
----@field formatter_lang_name string The name of this language for formatter.nvim (falls back to lang_name if not set), eg. "lua"
+---@field formatter_lang_name string? The name of this language for formatter.nvim (falls back to lang_name if not set), eg. "lua"
 ---@field formatters string[] An array of functions that initialise formatters
 ---@field linters string[] An array of linter names (strings)
 ---@field lsp_servers LspServerDefinition[] An array of LspServerDefinitions


### PR DESCRIPTION
Add support for enabling built in language support from the `nvim/lua/config/langs.lua`. Also adds a way to include custom language definitions.