### PR TITLE
Update the end of buffer fill char to space

### DIFF
--- a/nvim/lua/core/set.lua
+++ b/nvim/lua/core/set.lua
@@ -79,6 +79,9 @@ opt.scrolloff = 2
 opt.sidescrolloff = 15
 opt.sidescroll = 1
 
+-- set the end of buffer fill char to " " (space)
+opt.fillchars = { eob = " " }
+
 -- highlight yanked text for 200ms using the "Visual" highlight group
 cmd([[
     augroup highlight_yank


### PR DESCRIPTION
Prior to this change, little tildes appears at the bottom of each buffer.

This change updates that tilde character to be a space instead (effectively hiding this from the user).