### PR TITLE
Add an optional config section for langs to define mason extras

### DIFF
--- a/nvim/lua/core/lsp/mason.lua
+++ b/nvim/lua/core/lsp/mason.lua
@@ -33,6 +33,13 @@ local function get_used_tools_for_mason()
         for _, x in ipairs(config.lsp_servers) do
             table.insert(ret, x.lsp_name)
         end
+
+        -- get the extra mason tools
+        if config.extra_mason ~= nil then
+            for _, x in ipairs(config.extra_mason) do
+                table.insert(ret, x.lsp_name)
+            end
+        end
     end
     return ret
 end

--- a/nvim/lua/types.lua
+++ b/nvim/lua/types.lua
@@ -27,6 +27,7 @@
 ---@field formatters string[] An array of functions that initialise formatters
 ---@field linters string[] An array of linter names (strings)
 ---@field lsp_servers LspServerDefinition[] An array of LspServerDefinitions
+---@field extra_mason? string[] An array of extra tools to install with mason
 
 ---@class NvimLanguageConfig
 ---@field enabled_langs BuiltinLangs[] The list of enabled languages


### PR DESCRIPTION
Prior to this change, only linters, formatters and lsp servers were installed by `Mason`.

This change adds an exrra field in the language definition table so that you can add extra tools to the list of things that `Mason` auto-installs.