### PR TITLE
Swap python LSP to `basedpyright` from regular `pyright`

### DIFF
--- a/nvim/lua/core/langs/python.lua
+++ b/nvim/lua/core/langs/python.lua
@@ -10,7 +10,7 @@ local M = {
 
     lsp_servers = {
         {
-            lsp_name = "pyright",
+            lsp_name = "basedpyright",
             lsp_settings = {},
         },
         {


### PR DESCRIPTION
Prior to this change, regular `pyright` was being used.

This change swaps the python LSP to be `basedpyright` which is a fork of `pyright` that is looking to add extended features found in `based-mypy` and `pylance`.