### PR TITLE
Add support for jinja files

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,6 +1,9 @@
 -- set defaults
 require("core.set")
 
+-- set filetypes
+require("core.filetypes")
+
 -- setup plugins
 require("core.plugins")
 

--- a/nvim/lua/config/langs.lua
+++ b/nvim/lua/config/langs.lua
@@ -7,6 +7,7 @@ local lang_config = {
         "markdown",
         "svelte",
         "html",
+        "jinja",
         "typescript",
         "bash",
         "cpp",

--- a/nvim/lua/core/configs/treesitter.lua
+++ b/nvim/lua/core/configs/treesitter.lua
@@ -1,8 +1,12 @@
 local lang_configs = require("core.langs.init")
 
+print(vim.inspect(lang_configs))
+
 local lang_names = {}
 for _, config in pairs(lang_configs) do
-    table.insert(lang_names, config.lang_name)
+    if config.treesitter_exclude ~= true then
+        table.insert(lang_names, config.lang_name)
+    end
 end
 
 require("nvim-treesitter.configs").setup({

--- a/nvim/lua/core/filetypes.lua
+++ b/nvim/lua/core/filetypes.lua
@@ -1,0 +1,7 @@
+vim.filetype.add({
+    extension = {
+        jinja = "jinja",
+        jinja2 = "jinja",
+        j2 = "jinja",
+    },
+})

--- a/nvim/lua/core/langs/init.lua
+++ b/nvim/lua/core/langs/init.lua
@@ -13,6 +13,7 @@ if config.lang_config == nil then
             "markdown",
             "svelte",
             "html",
+            "jinja",
             "typescript",
             "bash",
             "cpp",

--- a/nvim/lua/core/langs/jinja.lua
+++ b/nvim/lua/core/langs/jinja.lua
@@ -1,0 +1,23 @@
+---@type LanguageDefinition
+local M = {
+    lang_name = "jinja",
+
+    formatters = { "prettier" },
+
+    linters = {},
+
+    lsp_servers = {
+        {
+            lsp_name = "html",
+            lsp_settings = {},
+        },
+        {
+            lsp_name = "jinja_lsp",
+            lsp_settings = {},
+        },
+    },
+
+    treesitter_exclude = true,
+}
+
+return M

--- a/nvim/lua/types.lua
+++ b/nvim/lua/types.lua
@@ -5,6 +5,7 @@
 ---| "markdown"
 ---| "svelte"
 ---| "html"
+---| "jinja"
 ---| "typescript"
 ---| "bash"
 ---| "cpp"
@@ -28,6 +29,7 @@
 ---@field linters string[] An array of linter names (strings)
 ---@field lsp_servers LspServerDefinition[] An array of LspServerDefinitions
 ---@field extra_mason? string[] An array of extra tools to install with mason
+---@field treesitter_exclude? boolean An array of extra tools to install with mason
 
 ---@class NvimLanguageConfig
 ---@field enabled_langs BuiltinLangs[] The list of enabled languages


### PR DESCRIPTION
Prior to this change, there was no way to use lsp, formatting and linting with jinja templates.

This change adds support for jinja filetypes and adds the language definitition for jinja files.