### PR TITLE
Add support for different treesitter langs

### DIFF
--- a/nvim/lua/core/configs/treesitter.lua
+++ b/nvim/lua/core/configs/treesitter.lua
@@ -4,9 +4,11 @@ print(vim.inspect(lang_configs))
 
 local lang_names = {}
 for _, config in pairs(lang_configs) do
-    if config.treesitter_exclude ~= true then
-        table.insert(lang_names, config.lang_name)
+    local treesitter_lang = config.lang_name
+    if config.treesitter_lang ~= nil then
+        treesitter_lang = config.treesitter_lang
     end
+    table.insert(lang_names, treesitter_lang)
 end
 
 require("nvim-treesitter.configs").setup({

--- a/nvim/lua/types.lua
+++ b/nvim/lua/types.lua
@@ -29,7 +29,7 @@
 ---@field linters string[] An array of linter names (strings)
 ---@field lsp_servers LspServerDefinition[] An array of LspServerDefinitions
 ---@field extra_mason? string[] An array of extra tools to install with mason
----@field treesitter_exclude? boolean An array of extra tools to install with mason
+---@field treesitter_lang? string The tree sitter syntax to use for this language
 
 ---@class NvimLanguageConfig
 ---@field enabled_langs BuiltinLangs[] The list of enabled languages


### PR DESCRIPTION
Prior to this change, there was no way to use a different treesitter syntax for a given language.

This change adds a new field `treesitter_lang` to the language config type and adds logic into the `treesitter.lua` file to ensure that the language name will be overwritten with the custom treesitter langauge name if specified.