### PR TITLE
Update the `jinja` to use html as treesitter language.

### DIFF
--- a/nvim/lua/core/langs/jinja.lua
+++ b/nvim/lua/core/langs/jinja.lua
@@ -17,7 +17,8 @@ local M = {
         },
     },
 
-    treesitter_exclude = true,
+    formatter_lang_name = "html",
+    treesitter_lang = "html",
 }
 
 return M


### PR DESCRIPTION
Prior to this change, the treesitter language for jinja was just excluded.

This change updates the config to use `html` as the treesitter language for `jinja` file types.