### PR TITLE
Register filetype with alternate treesitter syntax

### DIFF
--- a/nvim/lua/core/configs/treesitter.lua
+++ b/nvim/lua/core/configs/treesitter.lua
@@ -7,6 +7,7 @@ for _, config in pairs(lang_configs) do
     local treesitter_lang = config.lang_name
     if config.treesitter_lang ~= nil then
         treesitter_lang = config.treesitter_lang
+        vim.treesitter.language.register(treesitter_lang, config.lang_name)
     end
     table.insert(lang_names, treesitter_lang)
 end


### PR DESCRIPTION
Prior to this change, we were installing the custom treesitter syntax but we were not actually associating it with the new filetype.

This change associates a treesitter syntax with a file type if they differ in name using the `lang_name` and `treesitter_lang` fields.