### PR TITLE
Stop running Mason tools install on start

### DIFF
--- a/nvim/lua/core/lsp/mason.lua
+++ b/nvim/lua/core/lsp/mason.lua
@@ -47,4 +47,5 @@ end
 require("mason-tool-installer").setup({
     ensure_installed = get_used_tools_for_mason(),
     auto_update = true,
+    run_on_start = false,
 })


### PR DESCRIPTION
Prior to this change, mason tools install would run automatically on start. This would cause an error for any tools that are awaiting approval as a PR to the mason-registry repository.

This change makes the `mason-too-installer` only run manually for now. This will stop the error being raised every time nvim is open.

> [!NOTE]
> You should manual run `MasonToolsInstall` of `MasonToolsUpdate` if you want the tools required for this config installed!