### PR TITLE
fix: swap back to pyright from basedpyright

### DIFF
--- a/nvim/lua/core/langs/python.lua
+++ b/nvim/lua/core/langs/python.lua
@@ -10,7 +10,7 @@ local M = {
 
     lsp_servers = {
         {
-            lsp_name = "basedpyright",
+            lsp_name = "pyright",
             lsp_settings = {},
         },
         {


### PR DESCRIPTION
Prior to this change, basedpyright was being use. While it is better, it's just too slow on a large codebase and is making my work harder.

This change swapps back to `pyright` from `basedpyright` LSP.