### PR TITLE
feat: swap back to OG Pyright

### DIFF
--- a/nvim/lua/core/langs/python.lua
+++ b/nvim/lua/core/langs/python.lua
@@ -10,7 +10,7 @@ local M = {
 
     lsp_servers = {
         {
-            lsp_name = "basedpyright",
+            lsp_name = "pyright",
             lsp_settings = {
                 basedpyright = {
                     analysis = {


### PR DESCRIPTION
Prior to this change, this config used basedpyright. While i still believe it is a better product, its too slow on large codebases.

This change updates the LSP for python to be `pyright` not `basedpyright`.