### PR TITLE
fix: move gitbrowse utils to utils folder

### DIFF
--- a/nvim/lua/config/keys.lua
+++ b/nvim/lua/config/keys.lua
@@ -47,7 +47,7 @@ M.keymaps = {
         keys = "<leader>gbb",
         command = function()
             require("snacks").gitbrowse(
-                gitbrowse_utils.build_gitbrows_config(true, false)
+                gitbrowse_utils.build_gitbrowse_options(true, false)
             )
         end,
         opts = { desc = "Open file for branch in browser" },
@@ -57,7 +57,7 @@ M.keymaps = {
         keys = "<leader>gbb",
         command = function()
             require("snacks").gitbrowse(
-                gitbrowse_utils.build_gitbrows_config(true, true)
+                gitbrowse_utils.build_gitbrowse_options(true, true)
             )
         end,
         opts = { desc = "Open lines for branch in browser" },
@@ -67,7 +67,7 @@ M.keymaps = {
         keys = "<leader>gbm",
         command = function()
             require("snacks").gitbrowse(
-                gitbrowse_utils.build_gitbrows_config(false, false)
+                gitbrowse_utils.build_gitbrowse_options(false, false)
             )
         end,
         opts = { desc = "Open file for default branch in browser" },
@@ -77,7 +77,7 @@ M.keymaps = {
         keys = "<leader>gbm",
         command = function()
             require("snacks").gitbrowse(
-                gitbrowse_utils.build_gitbrows_config(false, true)
+                gitbrowse_utils.build_gitbrowse_options(false, true)
             )
         end,
         opts = { desc = "Open lines for default branch in browser" },

--- a/nvim/lua/core/utils/gitbrowse.lua
+++ b/nvim/lua/core/utils/gitbrowse.lua
@@ -37,7 +37,7 @@ end
 
 --- Build config to open lines in current branch
 ---@returns snacks.gitbrowse.Config
-function M.build_gitbrows_config(in_current_branch, is_visual)
+function M.build_gitbrowse_options(in_current_branch, is_visual)
     -- set defaults
     if in_current_branch == nil then in_current_branch = true end
     if is_visual == nil then is_visual = false end


### PR DESCRIPTION
This pull request updates the naming of a utility function and its usage in the Neovim configuration for git browsing actions. The changes are focused on improving code clarity and consistency by renaming both the function and its references.

Function and usage renaming for clarity:

* Renamed the function `build_gitbrows_config` to `build_gitbrowse_options` in `nvim/lua/core/utils/gitbrowse.lua` (previously `gitbrowse_utils.lua`) to better reflect its purpose and improve code readability.
* Updated all references to `build_gitbrows_config` to use the new name `build_gitbrowse_options` in the git browse key mappings in `nvim/lua/config/keys.lua`. [[1]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425L50-R50) [[2]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425L60-R60) [[3]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425L70-R70) [[4]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425L80-R80)