### PR TITLE
Swap pyright to ty

### DIFF
--- a/nvim/lua/config/keys.lua
+++ b/nvim/lua/config/keys.lua
@@ -1,5 +1,5 @@
 local config = require("config.features")
-local gitbrowse_utils = require("core.utils.gitbrowse")
+local gitbrowse_utils = require("core.utils.gitbrowse_utils")
 
 local M = {}
 

--- a/nvim/lua/core/langs/python.lua
+++ b/nvim/lua/core/langs/python.lua
@@ -10,20 +10,8 @@ local M = {
 
     lsp_servers = {
         {
-            lsp_name = "pyright",
-            lsp_settings = {
-                basedpyright = {
-                    analysis = {
-                        diagnosticMode = "workspace", -- openFilesOnly | workspace
-                        inlayHints = {
-                            callArgumentNames = true,
-                        },
-                        autoImportCompletions = true,
-                        autoSearchPaths = true,
-                    },
-                    disableOrganizeImports = true,
-                },
-            },
+            lsp_name = "ty",
+            lsp_settings = {},
         },
         {
             lsp_name = "ruff",


### PR DESCRIPTION
This pull request introduces new utilities for handling git branch-based file browsing and refactors related key mappings in Neovim. It also updates the default Python LSP configuration and makes minor formatting changes for consistency.

**Git branch browsing enhancements:**

* Added a new utility module `gitbrowse_utils.lua` that provides functions to determine the current and default git branch and to build configuration objects for opening files or line ranges in the browser, supporting both normal and visual modes.
* Refactored key mappings in `keys.lua` to use the new `gitbrowse_utils.build_gitbrows_config` function, introducing new mappings for opening the current file or selected lines on either the current or default branch in the browser (`<leader>gbb` and `<leader>gbm` in both normal and visual modes). [[1]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425R2) [[2]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425L45-R83)

**Python language server configuration:**

* Changed the default Python LSP from `pyright` to `ty` in `python.lua`, removing the previous custom settings for `pyright`.

**Formatting and consistency improvements:**

* Reformatted some anonymous function definitions in keymap entries for improved readability and consistency. [[1]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425L240-R277) [[2]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425L308-R345) [[3]](diffhunk://#diff-b84bad73b439c492f72c14bf94a1108050df518b95a523b697b1ab4308ada425L251-R288)